### PR TITLE
feat: added pipeline to build each microservice

### DIFF
--- a/.github/workflow/build.yml
+++ b/.github/workflow/build.yml
@@ -1,0 +1,25 @@
+name: Build each Microservice
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      matrix:
+        service: [  ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build ${{ matrix.service }}
+        run: cd src/${{ matrix.service }} && mvn clean install


### PR DESCRIPTION
Didnt get a chance to push this up earlier.

Since there will be multiple microservices in this repo this command will ``cd`` into each of them  before running teh build command.  
It uses a matrix to define what folders the microserves are in (currently empty, will need to be added to when services are added).

Closes #2


