### PR TITLE
fix: 401 for invalidt tokens

### DIFF
--- a/JwtAuthenticationGuideline/files-to-add/config/filter/JwtAuthenticationFilter.java
+++ b/JwtAuthenticationGuideline/files-to-add/config/filter/JwtAuthenticationFilter.java
@@ -51,7 +51,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         } catch (Exception e) {
-            handlerExceptionResolver.resolveException(request, response, null, e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Invalid Authentication Token");
+            response.getWriter().flush();
+            return;
         }
     }
 }

--- a/Microservices/IdentityMicroservice/src/main/java/cs4337/group_8/AuthenticationMicroservice/config/filters/JwtAuthenticationFilter.java
+++ b/Microservices/IdentityMicroservice/src/main/java/cs4337/group_8/AuthenticationMicroservice/config/filters/JwtAuthenticationFilter.java
@@ -54,7 +54,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         } catch (Exception e) {
-            handlerExceptionResolver.resolveException(request, response, null, e);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Invalid Authentication Token");
+            response.getWriter().flush();
+            return;
         }
     }
 }


### PR DESCRIPTION
When there is an invalid token, it was handled incorrectly and return 200 OK instead of 401 Unauthorized. 
It never actually let the token bypass, but 401 is more suiting 